### PR TITLE
버튼 컴포넌트 (싱글버튼 · 더블버튼) 개발

### DIFF
--- a/src/components/common/DoubleButton.tsx
+++ b/src/components/common/DoubleButton.tsx
@@ -1,32 +1,16 @@
-interface ButtonProps {
-  positiveText: string;
-  negativeText: string;
-  positiveClick?: React.MouseEventHandler<HTMLButtonElement>;
-  negativeClick?: React.MouseEventHandler<HTMLButtonElement>;
-}
+import { ButtonProps, FilledButton } from "./FilledButton";
 
-export const DoubleButton = ({
-  positiveText,
-  negativeText,
-  positiveClick,
-  negativeClick,
-}: ButtonProps) => {
+type DoubleButtonProps = {
+  mainButton: ButtonProps;
+  subButton: ButtonProps;
+};
+
+/** 더블 버튼 컴포넌트, 메인 버튼(mainButton)과 서브 버튼(subButton)을 필요로 합니다. */
+export const DoubleButton = ({ mainButton, subButton }: DoubleButtonProps) => {
   return (
     <div className="w-360px flex h-146px flex-col gap-y-2 px-20px pb-32px pt-12px">
-      <button
-        type="button"
-        className="flex h-54px w-full items-center justify-center rounded-2 border bg-[#242B37] py-16px font-semibold text-white"
-        onClick={positiveClick}
-      >
-        {positiveText}
-      </button>
-      <button
-        type="button"
-        className="flex h-54px w-full items-center justify-center rounded-2 bg-white py-16px font-semibold text-blue-500"
-        onClick={negativeClick}
-      >
-        {negativeText}
-      </button>
+      <FilledButton className="bg-[#242B37] text-white" {...mainButton} />
+      <FilledButton className="bg-white text-blue-500" {...subButton} />
     </div>
   );
 };

--- a/src/components/common/FilledButton.tsx
+++ b/src/components/common/FilledButton.tsx
@@ -1,0 +1,20 @@
+import clsx from "clsx";
+
+export type ButtonProps = {
+  text: string;
+} & Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "type">;
+
+export const FilledButton = ({ text, className, ...props }: ButtonProps) => {
+  return (
+    <button
+      type="button"
+      className={clsx(
+        "flex h-54px w-full items-center justify-center rounded-2 border bg-[#242B37] py-16px",
+        className ? className : "bg-[#242B37] text-white",
+      )}
+      {...props}
+    >
+      {text}
+    </button>
+  );
+};

--- a/src/components/common/SingleButton.tsx
+++ b/src/components/common/SingleButton.tsx
@@ -1,17 +1,14 @@
-type ButtonProps = {
-  text: string;
-} & Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "type">;
+import { ButtonProps, FilledButton } from "./FilledButton";
 
-export const SingleButton = ({ text, ...props }: ButtonProps) => {
+type SingleButtonProps = {
+  mainButton: ButtonProps;
+};
+
+/** 싱글 버튼 컴포넌트, 메인 버튼(mainButton)을 필요로 합니다. */
+export const SingleButton = ({ mainButton }: SingleButtonProps) => {
   return (
     <div className="w-360px h-98px px-20px pb-32px pt-12px">
-      <button
-        type="button"
-        className="flex h-54px w-full items-center justify-center rounded-2 border bg-[#242B37] py-16px font-semibold text-white"
-        {...props}
-      >
-        {text}
-      </button>
+      <FilledButton {...mainButton} />
     </div>
   );
 };


### PR DESCRIPTION
> ### 싱글 버튼 구현
---

## 🙋‍ Summary (요약)
- 화면에 들어가는 공통 싱글 버튼 컴포넌트를 개발하였습니다.
- 해당 버튼을 통해 각 페이지별 플로우 이동이 가능합니다.
<img width="481" alt="스크린샷 2023-12-28 오전 1 33 15" src="https://github.com/depromeet/P.P-client/assets/19422885/9a879a87-de30-43dc-b73b-7b5b7129b1c8">

## 🤔 Describe your Change (변경사항)
- `SingleButton.tsx`

## 🔗 Issue number and link (참고)
- closes: #49 
- closes: #50 
