### PR TITLE
fix: 단일 버튼 클래스 네임이 잘 들어가도록 수정

### DIFF
--- a/src/components/common/fiiled-button.tsx
+++ b/src/components/common/fiiled-button.tsx
@@ -21,12 +21,12 @@ export const FilledButton = ({
       type="button"
       className={clsx(
         "flex h-54px w-full items-center justify-center rounded-2 py-16px disabled:bg-gray-400 disabled:text-gray-500",
+        className,
         {
           "text-b2-strong bg-[#242B37] text-white": colorSchema === "primary",
-          "text-b3-strong h-40px bg-white text-blue-500":
+          "text-b3-strong h-40px bg-transparent text-blue-500":
             colorSchema === "white",
           "rounded-none": isFull && isFullStyle,
-          className,
         },
       )}
       {...props}


### PR DESCRIPTION
> ### 단일 버튼 클래스 네임이 반영되지 않는 현상
---

## 🙋‍ Summary (요약)
- 단일 버튼 클래스 네임이 반영되지 않아 위치를 수정하였습니다.

## 🤔 Describe your Change (변경사항)
- `filled-button.tsx`

## 🔗 Issue number and link (참고)
- 
