### PR TITLE
fix: 네이버 플랫폼 환경에서 화면의 세로 길이가 정상적으로 출력되지 않는 현상 수정

### DIFF
--- a/src/components/layout/default.tsx
+++ b/src/components/layout/default.tsx
@@ -26,7 +26,7 @@ export const DefaultLayout = ({
       {resetScroll && <UseScrollToTop />}
       <div
         className={clsx(
-          "relative mx-auto flex min-h-[100dvh] w-screen max-w-[480px] flex-col shadow scrollbar-hide",
+          "relative mx-auto flex h-screen max-h-[100dvh] w-screen max-w-[480px] flex-col shadow scrollbar-hide",
           className,
         )}
       >


### PR DESCRIPTION
> ### 네이버 플랫폼 환경에서 화면의 세로 길이가 정상적으로 출력되지 않는 현상 수정
---

## 🙋‍ Summary (요약)
- 네이버 모바일 플랫폼 환경에서 화면의 세로 길이가 정상적으로 출력되지 않는 현상을 수정하였습니다.

## 🤔 Describe your Change (변경사항)
- `layout/default.tsx`

## 🔗 Issue number and link (참고)
- closes: #152 
