### PR TITLE
fix: QA 반영사항 수정

### DIFF
--- a/src/app/error/404.tsx
+++ b/src/app/error/404.tsx
@@ -1,13 +1,16 @@
+import Cookies from "js-cookie";
 import { useNavigate } from "react-router-dom";
 
 import ErrorImg from "@/assets/images/404.svg?react";
 import { ButtonProvider } from "@/components/common/button-provider";
 import { DefaultLayout } from "@/components/layout/default";
-import useUserStore from "@/features/useUserStore";
+// import useUserStore from "@/features/useUserStore";
 
 export const NotFound = () => {
   const navigate = useNavigate();
-  const { isLogin } = useUserStore();
+  // TODO: 추후 JWT 토큰 구현 시, 토큰 관련 로직으로 변경
+  // const { isLogin } = useUserStore();
+  const isLogin = Boolean(Cookies.get("k-u-id"));
 
   return (
     <DefaultLayout>
@@ -20,7 +23,11 @@ export const NotFound = () => {
       </article>
       <ButtonProvider>
         {/* TODO: 카카오 로그인 연동 후, 로그인이 되지 않은 상태일 경우에는 다른 메세지 제공 */}
-        <ButtonProvider.Primary onClick={() => navigate("/")}>
+        <ButtonProvider.Primary
+          onClick={() => {
+            isLogin ? navigate("/main") : navigate("/");
+          }}
+        >
           {isLogin ? "메인 홈으로 돌아가기" : "처음으로 돌아가기"}
         </ButtonProvider.Primary>
       </ButtonProvider>

--- a/src/components/layout/default.tsx
+++ b/src/components/layout/default.tsx
@@ -26,7 +26,7 @@ export const DefaultLayout = ({
       {resetScroll && <UseScrollToTop />}
       <div
         className={clsx(
-          "relative mx-auto flex h-screen max-h-[100dvh] w-screen max-w-[480px] flex-col shadow scrollbar-hide",
+          "relative mx-auto flex min-h-[100dvh] w-screen max-w-[480px] flex-col shadow scrollbar-hide",
           className,
         )}
       >

--- a/src/hooks/api/signup/useApiUserName.ts
+++ b/src/hooks/api/signup/useApiUserName.ts
@@ -18,7 +18,7 @@ export const useApiUserProfile = () => {
 
   return useMutation({
     mutationFn: (nickname: string) => changeNickName(nickname),
-    onSuccess: () => naviagate("/main"),
+    onSuccess: () => naviagate("/post/keyword"),
     onError: () => naviagate("/error"),
   });
 };


### PR DESCRIPTION
> ### QA 반영사항 수정
---

## 🙋‍ Summary (요약)
- QA를 위한 AOS 네이버 플랫폼 height 값 임시 수정 원복
- 로그인이 되어있는 사용자가 404 페이지에서 메인화면으로 돌아가기 클릭 시, 회원가입 페이지로 가는 현상 수정
- 온보딩 후, 바로 게시물 작성 페이지로 갈 수 있도록 수정

## 🤔 Describe your Change (변경사항)
- `404.tsx`
- `layout/default.tsx`
- `signup/useApiUserName.ts`

## 🔗 Issue number and link (참고)
- closes: #152 
